### PR TITLE
Fix: Windows titlebar controls now change color with dark/light theme

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -374,3 +374,25 @@ ipcMain.handle('window-close', () => {
 ipcMain.handle('window-is-maximized', () => {
   return mainWindow.isMaximized();
 });
+
+/**
+ * IPC-Handler für Theme-Wechsel - Aktualisiert die Titlebar-Farben
+ */
+ipcMain.handle('update-titlebar-theme', (event, isDarkTheme) => {
+  try {
+    if (mainWindow && process.platform === 'win32') {
+      // Aktualisiere die Titlebar-Overlay-Farben basierend auf dem Theme
+      mainWindow.setTitleBarOverlay({
+        color: isDarkTheme ? '#1e293b' : '#ffffff',
+        symbolColor: isDarkTheme ? '#ffffff' : '#333333',
+        height: 40
+      });
+      
+      console.log(`🎨 Titlebar-Theme aktualisiert: ${isDarkTheme ? 'Dark' : 'Light'}`);
+    }
+    return true;
+  } catch (error) {
+    console.error('Fehler beim Aktualisieren des Titlebar-Themes:', error);
+    return false;
+  }
+});

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -46,6 +46,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   /**
+   * Aktualisiert die Titlebar-Farben basierend auf dem aktuellen Theme
+   * @param {boolean} isDarkTheme - true für Dark Theme, false für Light Theme
+   * @returns {Promise<boolean>} Erfolg der Aktualisierung
+   */
+  updateTitlebarTheme: (isDarkTheme) => ipcRenderer.invoke('update-titlebar-theme', isDarkTheme),
+
+  /**
    * Progress-Event-Listener für Performance-optimierte Foto-Verarbeitung
    * @param {function} callback - Callback-Funktion für Progress-Updates
    */

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -656,7 +656,7 @@ function showNoPhotosState(day, month) {
 /**
  * Wechselt zwischen Dark und Light Theme
  */
-function toggleTheme() {
+async function toggleTheme() {
     const body = document.body;
     const isDark = body.classList.contains('dark-theme');
     
@@ -671,6 +671,9 @@ function toggleTheme() {
             lucide.createIcons();
         }
         
+        // Titlebar-Theme aktualisieren
+        await window.electronAPI.updateTitlebarTheme(false);
+        
         localStorage.setItem('theme', 'light');
         showToast('Light Theme aktiviert');
     } else {
@@ -684,6 +687,9 @@ function toggleTheme() {
             lucide.createIcons();
         }
         
+        // Titlebar-Theme aktualisieren
+        await window.electronAPI.updateTitlebarTheme(true);
+        
         localStorage.setItem('theme', 'dark');
         showToast('Dark Theme aktiviert');
     }
@@ -692,14 +698,15 @@ function toggleTheme() {
 /**
  * Lädt das gespeicherte Theme beim Start
  */
-function loadSavedTheme() {
+async function loadSavedTheme() {
     const savedTheme = localStorage.getItem('theme');
     const body = document.body;
+    const isDarkTheme = savedTheme === 'dark';
     
     // Alle Theme-Klassen entfernen
     body.classList.remove('light-theme', 'dark-theme');
     
-    if (savedTheme === 'dark') {
+    if (isDarkTheme) {
         body.classList.add('dark-theme');
         
         if (elements.themeIcon) {
@@ -711,6 +718,15 @@ function loadSavedTheme() {
         
         if (elements.themeIcon) {
             elements.themeIcon.setAttribute('data-lucide', 'sun');
+        }
+    }
+    
+    // Titlebar-Theme beim Start setzen
+    if (window.electronAPI && window.electronAPI.updateTitlebarTheme) {
+        try {
+            await window.electronAPI.updateTitlebarTheme(isDarkTheme);
+        } catch (error) {
+            console.error('Fehler beim Setzen des initialen Titlebar-Themes:', error);
         }
     }
     


### PR DESCRIPTION
- Added IPC handler for dynamic titlebar theme updates
- Windows titlebar controls now use dark colors in dark theme
- Light theme uses light titlebar colors
- Theme is applied on startup and when switching themes
- Fixes issue where titlebar controls remained white in dark theme